### PR TITLE
Feature/verify email get not post

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -86,6 +86,7 @@ jobs:
               -e MAIL_USERNAME="${{ secrets.MAIL_USERNAME }}" \
               -e MAIL_PASSWORD="${{ secrets.MAIL_PASSWORD }}" \
               -e MAIL_FROM="${{ secrets.MAIL_FROM }}" \
+              -e API_BASE_URL="${{ secrets.API_BASE_URL }}" \
               -e FRONTEND_URL="${{ secrets.FRONTEND_URL }}" \
               ${{ steps.build-image.outputs.IMAGE_URI }}
 

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -4,7 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main 
+      - main
+      - feature/verify-email-get-not-post
 
 permissions:
   id-token: write # Required for OIDC authentication

--- a/app/api/core/email.py
+++ b/app/api/core/email.py
@@ -22,7 +22,7 @@ conf = ConnectionConfig(
 
 async def send_verification_email(email: str, token: str):
     try:
-        verification_url = f"{os.getenv('FRONTEND_URL', 'http://localhost:8000')}/api/v1/users/verify-email?token={token}"
+        verification_url = f"{os.getenv('API_BASE_URL', 'http://localhost:8000').strip('/')}/api/v1/users/verify-email?token={token}"
 
         message = MessageSchema(
             subject="Verify your email for Cargo-Connect",


### PR DESCRIPTION
This PR addresses issues with the email verification flow:

1. __`app/api/core/email.py`:__

   - Updates email verification link generation to use the `API_BASE_URL` environment variable. This ensures links correctly point to the deployed backend API, rather than a potentially misconfigured `FRONTEND_URL`.
   - Includes `.strip('/')` for robust URL construction.

2. __`app/api/v1/routes/user.py`:__

   - Changes the `/users/verify-email` endpoint from `POST` to `GET` to correctly handle link clicks from emails.
   - Modifies the endpoint to expect the verification token as a query parameter (`?token=...`) instead of a path parameter.
   - After successful verification, the user is now redirected to the URL specified by the `FRONTEND_URL` environment variable (expected to be the frontend application's login page, e.g., `http://localhost:3000/auth/login`), with a `verification_status=success` query parameter.
   - Adds necessary imports (`os`, `RedirectResponse`) and updates the function signature.

These changes ensure that verification links are generated correctly, the API endpoint handles them as expected from a browser click, and the user is properly redirected to the frontend application after verification. This setup also allows for distinct configuration of the backend's public URL (`API_BASE_URL`) and the frontend's URL (`FRONTEND_URL`) for redirection.
